### PR TITLE
Pure JS function callbacks

### DIFF
--- a/src/backend/builtin_functions.ts
+++ b/src/backend/builtin_functions.ts
@@ -70,7 +70,4 @@ export function addBuiltins(ctx: Context) {
     const arena_heap_reset = mod.block(null, [ARENA_HEAP_OFFSET.set(i32.const(0))]);
     mod.addFunction("arena_heap_reset", binaryen.none, binaryen.none, [], arena_heap_reset);
     mod.addFunctionExport("arena_heap_reset", "$arena_heap_reset");
-
-    mod.addFunction("noop", binaryen.i32, binaryen.none, [], mod.block(null, []));
-    mod.addFunctionExport("noop", "$noop");
 }

--- a/src/backend/builtin_functions.ts
+++ b/src/backend/builtin_functions.ts
@@ -70,4 +70,7 @@ export function addBuiltins(ctx: Context) {
     const arena_heap_reset = mod.block(null, [ARENA_HEAP_OFFSET.set(i32.const(0))]);
     mod.addFunction("arena_heap_reset", binaryen.none, binaryen.none, [], arena_heap_reset);
     mod.addFunctionExport("arena_heap_reset", "$arena_heap_reset");
+
+    mod.addFunction("noop", binaryen.i32, binaryen.none, [], mod.block(null, []));
+    mod.addFunctionExport("noop", "$noop");
 }

--- a/src/backend/type_classes.ts
+++ b/src/backend/type_classes.ts
@@ -30,6 +30,7 @@ import {
     VIRTUALIZED_FUNCTIONS
 } from "./utils.js";
 import { BinaryOperator, TokenType } from "../types/tokens.js";
+import { RESERVED_FN_PTRS } from "./code_generation.js";
 
 export abstract class MiteType {
     // get the value as a primitive (pointer for structs and arrays, value for locals)
@@ -1147,7 +1148,9 @@ export class DirectFunction implements MiteType {
                     new TransientPrimitive(
                         this.ctx,
                         Pointer.type,
-                        this.ctx.mod.i32.const(this.ctx.captured_functions.indexOf(captured_name))
+                        this.ctx.mod.i32.const(
+                            RESERVED_FN_PTRS + this.ctx.captured_functions.indexOf(captured_name)
+                        )
                     )
                 )
         );

--- a/src/backend/type_classes.ts
+++ b/src/backend/type_classes.ts
@@ -30,7 +30,6 @@ import {
     VIRTUALIZED_FUNCTIONS
 } from "./utils.js";
 import { BinaryOperator, TokenType } from "../types/tokens.js";
-import { RESERVED_FN_PTRS } from "./code_generation.js";
 
 export abstract class MiteType {
     // get the value as a primitive (pointer for structs and arrays, value for locals)
@@ -1149,7 +1148,8 @@ export class DirectFunction implements MiteType {
                         this.ctx,
                         Pointer.type,
                         this.ctx.mod.i32.const(
-                            RESERVED_FN_PTRS + this.ctx.captured_functions.indexOf(captured_name)
+                            this.ctx.constants.RESERVED_FN_PTRS +
+                                this.ctx.captured_functions.indexOf(captured_name)
                         )
                     )
                 )

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -323,3 +323,30 @@ export function getParameterCallbackCounts(ctx: Context, program: Program): [str
 
     return Object.entries(counts).sort((a, b) => a[1] - b[1]);
 }
+
+export function addDataSegment(
+    ctx: Context,
+    segment_name: string,
+    memory_name: string,
+    offset: binaryen.ExpressionRef,
+    data: Uint8Array
+) {
+    // @ts-expect-error undocumented binaryen export
+    const data_ptr = binaryen._malloc(data.length);
+    // @ts-expect-error undocumented binaryen export
+    new Uint8Array(binaryen.HEAPU8.buffer, data_ptr, data.length).set(data);
+    // @ts-expect-error undocumented binaryen export
+    binaryen._BinaryenAddDataSegment(
+        ctx.mod.ptr,
+        // @ts-expect-error undocumented binaryen export
+        binaryen.stringToUTF8OnStack(segment_name),
+        // @ts-expect-error undocumented binaryen export
+        binaryen.stringToUTF8OnStack(memory_name),
+        false,
+        offset,
+        data_ptr,
+        data.length
+    );
+    // @ts-expect-error undocumented binaryen export
+    binaryen._free(data.byteOffset);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,14 +4,35 @@ import { compile } from "./compiler.js";
 const program = await fs.readFile(process.argv[2], "utf8");
 
 console.log(compile(program, { as: "wat", optimize: false }));
+console.log(
+    compile(program, {
+        as: "javascript",
+        createInstance(imports) {
+            return {
+                instantiation: `WebAssembly.instantiate(Uint8Array.from(atob("atea"), (c) => c.charCodeAt(0)), ${imports})`
+            };
+        }
+    })
+);
+console.log(compile(program, { as: "dts" }));
 
 const output = compile(program);
 
 await fs.writeFile("out.wasm", output);
 
 const compiled = new WebAssembly.Module(output);
-// @ts-expect-error this works
-const instance = new WebAssembly.Instance(compiled, { console });
+
+// prettier-ignore
+const instance = new WebAssembly.Instance(compiled, {
+    // @ts-expect-error this works
+    console,
+    $mite: new Proxy({}, {
+        get(_, prop) {
+            // @ts-expect-error this works
+            if (prop.startsWith("wrap_")) { return function (ptr, ...args) { return $funcs[ptr](...args); }; }
+        }
+    })
+});
 
 // @ts-expect-error this works
 console.log(instance.exports.main());

--- a/src/types/code_gen.ts
+++ b/src/types/code_gen.ts
@@ -103,7 +103,7 @@ export type Context = {
         i64x2: PrimitiveTypeInformation;
         u64x2: PrimitiveTypeInformation;
         f64x2: PrimitiveTypeInformation;
-        string: StringTypeInformation;
+        string: InstanceStringTypeInformation;
     } & Record<string, TypeInformation>;
     /** Depth stacks for use in nested blocks and such */
     stacks: {
@@ -121,6 +121,10 @@ export type Context = {
     string: {
         literals: Map<string, number>;
         end: number;
+    };
+    /** constants that don't fit elsewhere */
+    constants: {
+        RESERVED_FN_PTRS: number;
     };
     /** Data about current function */
     current_function: FunctionInformation & {


### PR DESCRIPTION
Adds the ability to directly use javascript callbacks in functions that accept a function parameter

Caveats:
- can't store callbacks past lifetime of function
- can't return callbacks from a callback
- will need to be taken into account in memory management, as it's another black box where references to a struct can be taken (prior to this PR they could only be stored in inputted containers or returned)