### PR TITLE
Add global variables

### DIFF
--- a/src/backend/type_classes.ts
+++ b/src/backend/type_classes.ts
@@ -946,6 +946,22 @@ export class GlobalPrimitive extends Primitive {
         private readonly global_name: string
     ) {
         super(ctx, type);
+        const zero =
+            this.binaryenType === binaryen.i32
+                ? ctx.mod.i32.const(0)
+                : this.binaryenType === binaryen.i64
+                  ? ctx.mod.i64.const(0, 0)
+                  : this.binaryenType === binaryen.f32
+                    ? ctx.mod.f32.const(0)
+                    : this.binaryenType === binaryen.f64
+                      ? ctx.mod.f64.const(0)
+                      : this.binaryenType === binaryen.v128
+                        ? ctx.mod.v128.const(new Uint8Array(16))
+                        : (() => {
+                              throw new Error("invalid binaryen type");
+                          })();
+
+        ctx.mod.addGlobal(global_name, this.binaryenType, true, zero);
     }
 
     get_expression_ref(): binaryen.ExpressionRef {

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -9,6 +9,7 @@ import {
 } from "../types/code_gen.js";
 import {
     Array_,
+    GlobalPrimitive,
     IndirectFunction,
     LinearMemoryPrimitive,
     LocalPrimitive,
@@ -52,13 +53,18 @@ export function lookForVariable(ctx: Context, name: string): MiteType {
 export function createMiteType(
     ctx: Context,
     type: InstanceTypeInformation,
-    address_or_local: MiteType | number
+    address_or_local: MiteType | number | string
 ): MiteType {
-    if (typeof address_or_local === "number") {
+    if (typeof address_or_local === "number" || typeof address_or_local === "string") {
         if (type.classification === "primitive") {
-            return new LocalPrimitive(ctx, type, address_or_local);
+            return typeof address_or_local === "number"
+                ? new LocalPrimitive(ctx, type, address_or_local)
+                : new GlobalPrimitive(ctx, type, address_or_local);
         } else {
-            const local = new LocalPrimitive(ctx, Pointer.type, address_or_local);
+            const local =
+                typeof address_or_local === "number"
+                    ? new LocalPrimitive(ctx, Pointer.type, address_or_local)
+                    : new GlobalPrimitive(ctx, Pointer.type, address_or_local);
             if (type.classification === "array") {
                 return new Array_(ctx, type, new Pointer(local));
             } else if (type.classification === "struct") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,11 @@ console.log(
         as: "wat",
         optimize: false,
         resolveImport() {
-            return Promise.resolve("");
+            return Promise.resolve({
+                isMite: false,
+                absolute: "",
+                code: ""
+            });
         }
     })
 );
@@ -26,7 +30,11 @@ console.log(await compile(program, { as: "dts" }));
 
 const output = await compile(program, {
     resolveImport() {
-        return Promise.resolve("");
+        return Promise.resolve({
+            isMite: false,
+            absolute: "",
+            code: ""
+        });
     }
 });
 

--- a/src/tests/structs.test.ts
+++ b/src/tests/structs.test.ts
@@ -20,7 +20,11 @@ describe("struct declarations", async () => {
 
         await assert.rejects(() =>
             compile(program, {
-                resolveImport: async () => ""
+                resolveImport: async () => ({
+                    isMite: false,
+                    absolute: "",
+                    code: ""
+                })
             })
         );
 
@@ -41,7 +45,11 @@ describe("struct declarations", async () => {
 
         await assert.rejects(() =>
             compile(program2, {
-                resolveImport: async () => ""
+                resolveImport: async () => ({
+                    isMite: false,
+                    absolute: "",
+                    code: ""
+                })
             })
         );
 
@@ -61,7 +69,11 @@ describe("struct declarations", async () => {
 
         await assert.rejects(() =>
             compile(program3, {
-                resolveImport: async () => ""
+                resolveImport: async () => ({
+                    isMite: false,
+                    absolute: "",
+                    code: ""
+                })
             })
         );
 
@@ -72,7 +84,11 @@ describe("struct declarations", async () => {
 
         await assert.rejects(() =>
             compile(program4, {
-                resolveImport: async () => ""
+                resolveImport: async () => ({
+                    isMite: false,
+                    absolute: "",
+                    code: ""
+                })
             })
         );
 
@@ -83,7 +99,11 @@ describe("struct declarations", async () => {
 
         await assert.rejects(() =>
             compile(program5, {
-                resolveImport: async () => ""
+                resolveImport: async () => ({
+                    isMite: false,
+                    absolute: "",
+                    code: ""
+                })
             })
         );
     });
@@ -106,7 +126,11 @@ describe("struct declarations", async () => {
         `;
 
         await compile(program, {
-            resolveImport: async () => ""
+            resolveImport: async () => ({
+                isMite: false,
+                absolute: "",
+                code: ""
+            })
         });
     });
 });

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -8,7 +8,11 @@ export async function compileAndRun(
     func: string = "main"
 ) {
     const compiled = await compile(program, {
-        resolveImport: async () => ""
+        resolveImport: async () => ({
+            isMite: false,
+            absolute: "",
+            code: ""
+        })
     });
     // console.log(compile(program, { as: "wat" }));
 


### PR DESCRIPTION
Adds global variables

Caveats:
- you have to annotate them even with an initializer so that the boilerplate generation can have type information
   - Could just be applied to exports but for now applies to both for consistency
- globals aren't updated past their initial state on the javascript side
   - when `const` is fixed proper, should require exported globals to be `const`
